### PR TITLE
Update periph import path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/jimnelson2/tsl2591
 
-go 1.13
+go 1.17
 
-require periph.io/x/periph v3.6.2+incompatible
+require (
+	periph.io/x/conn/v3 v3.7.0
+	periph.io/x/host/v3 v3.8.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,7 @@
-periph.io/x/periph v3.6.2+incompatible h1:B9vqhYVuhKtr6bXua8N9GeBEvD7yanczCvE0wU2LEqw=
-periph.io/x/periph v3.6.2+incompatible/go.mod h1:EWr+FCIU2dBWz5/wSWeiIUJTriYv9v2j2ENBmgYyy7Y=
+github.com/jonboulle/clockwork v0.3.0 h1:9BSCMi8C+0qdApAp4auwX0RkLGUjs956h0EkuQymUhg=
+github.com/jonboulle/clockwork v0.3.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
+periph.io/x/conn/v3 v3.7.0 h1:f1EXLn4pkf7AEWwkol2gilCNZ0ElY+bxS4WE2PQXfrA=
+periph.io/x/conn/v3 v3.7.0/go.mod h1:ypY7UVxgDbP9PJGwFSVelRRagxyXYfttVh7hJZUHEhg=
+periph.io/x/d2xx v0.1.0/go.mod h1:OflHQcWZ4LDP/2opGYbdXSP/yvWSnHVFO90KRoyobWY=
+periph.io/x/host/v3 v3.8.0 h1:T5ojZ2wvnZHGPS4h95N2ZpcCyHnsvH3YRZ1UUUiv5CQ=
+periph.io/x/host/v3 v3.8.0/go.mod h1:rzOLH+2g9bhc6pWZrkCrmytD4igwQ2vxFw6Wn6ZOlLY=


### PR DESCRIPTION
Thanks for the nice library! 

Wanted to use it for [my alarm clock](https://github.com/JenswBE/sunrise-alarm), so bumped it to the latest version of  Periphio. Next to this, bumped `go.mod` to 1.17 to be aligned with https://github.com/periph/host/blob/main/go.mod. Also, improved error logging and added support for selecting bus in options.

Changes have been validated with Raspberry Pi 4 using Go 1.18.8.